### PR TITLE
separated text generation from file writing

### DIFF
--- a/src/infer.pl
+++ b/src/infer.pl
@@ -10,6 +10,7 @@ with a few minor changes:
 - in the function application (t t0) rule, the premise that enforces that t is a lambda term is checked, but it's not memorized
 in the final tree to save some space
 - the same reasoning is applied in the fst(t) and snd(t) rules, for the premies that checks if t is a tuple*/
+
 derive(Derivation,red(int(N),int(N))):-
     Derivation = infer(int,red(int(N),int(N)),[]).
 

--- a/src/latex.pl
+++ b/src/latex.pl
@@ -5,6 +5,7 @@ Tab variable, which is equal for rules at the same height in the tree*/
 :- module(latex,[write_to_file/3]).
 
 :-use_module(repr).
+:-use_module(write_tree).
 
 
 /* tree width is used to compute how much width is necessary to write the full tree in a pdf file*/
@@ -32,8 +33,10 @@ write_to_file(infer(R,red(T,C),Tree),File,Short):-
     /* set up the tex file and then write the full tree recursively*/
     open(File, write, FileStream),
     write_preamble(FileStream,N1),
-    write_tree(D,FileStream,0),
-    end_proof(FileStream),
+    writeln(FileStream,""),
+    
+    tree_to_latex(D,String),
+    writeln(FileStream,String),
     end_file(FileStream).
   
       
@@ -45,55 +48,17 @@ write_preamble(FileStream,PageWidth) :-
     writeln(FileStream,"\\begin{document}"),
     swritef(S,"\\pdfpagewidth=%win",[PageWidth]),
     writeln(FileStream,"\\pdfpageheight=11in"),
-    writeln(FileStream,S),
-    writeln(FileStream,"\\begin{prooftree}").
+    writeln(FileStream,S).
 
-end_proof(FileStream):-
-    writeln(FileStream,"\\end{prooftree}").
+
     
 end_file(FileStream):- 
 writeln(FileStream,"\\end{document}"),
 close(FileStream).
 
-write_tree(infer(R,red(A,B),[]),FileStream,Tab):- /** rules without premises*/
-    repr(A,S),
-    repr(B,S1),
-    tab(FileStream, Tab+4),
-    writeln(FileStream, "\\AxiomC{}"),
-    tab(FileStream,Tab+4),
-    
-    swritef(F1,"\\RightLabel{%w}",[R]),
-    writeln(FileStream, F1),
-    tab(FileStream, Tab+4),
-    
-    swritef(F2,"\\UnaryInfC{$ %w \\Rightarrow %w$}",[S,S1]),
-    writeln(FileStream,F2).
 
-write_tree(infer(R,red(A,B),[D1]),FileStream,Tab):-
-    /* predicate used for rules with a single premise,
-    the premise is colored blue*/
-    write_tree(D1,FileStream,Tab),
-    repr(A, S1),
-    repr(B, S2),
-    swritef(F1,"\\RightLabel{%w}",[R]),
-    tab(FileStream,Tab+4),
-    writeln(FileStream,F1),
-    tab(FileStream,Tab+4),
-    swritef(F2,"\\UnaryInfC{$ %w \\Rightarrow %w$}",[S1,S2]),
-    writeln(FileStream,F2).
 
-write_tree(infer(R,red(A,B),[D1,D2]),FileStream,Tab):-
-    /* predicates with two premises, the left one is colored red and the right one is colored green instead*/
-    write_tree(D1,FileStream,Tab),
-    write_tree(D2,FileStream, Tab+8),
-    repr(A, S1),
-    repr(B, S2),
-    tab(FileStream, Tab+4),
-    swritef(F1,"\\LeftLabel{%w}",[R]),
-    writeln(FileStream,F1),
-    tab(FileStream, Tab+4),
-    swritef(F2,"\\BinaryInfC{$ %w \\Rightarrow %w$}",[S1,S2]),
-    writeln(FileStream,F2).
+
 
 
 

--- a/src/write_tree.pl
+++ b/src/write_tree.pl
@@ -1,0 +1,52 @@
+:- module(write_tree, [tree_to_latex/2]).
+:- use_module(library(lists)).
+:- use_module(repr).
+
+tree_to_latex(Tree, String):-
+    string_chars("\\begin{prooftree}\n", R1),
+    write_tree_lat(Tree,R2),
+    string_chars("\\end{prooftree}\n", R3),
+    append([R1,R2,R3],Repr),
+    string_chars(String, Repr).
+    
+
+    
+
+write_tree_lat(infer(R,red(A,B),[]),Repr):- /** rules without premises*/
+    repr(A,S),
+    repr(B,S1),
+    swritef(F,"\\AxiomC{}\n"),
+    swritef(F1,"\\RightLabel{%w}\n",[R]),
+    swritef(F2,"\\UnaryInfC{$ %w \\Rightarrow %w$}\n",[S,S1]),
+    string_chars(F, R1),
+    string_chars(F1, R2),
+    string_chars(F2, R3),
+    append([R1,R2,R3], Repr).
+
+write_tree_lat(infer(R,red(A,B),[D1]),Repr):-
+    /* predicate used for rules with a single premise,
+    the premise is colored blue*/
+    write_tree_lat(D1,Repr1),
+    repr(A, S1),
+    repr(B, S2),
+    swritef(F1,"\\RightLabel{%w}\n",[R]),
+    swritef(F2,"\\UnaryInfC{$ %w \\Rightarrow %w$}\n",[S1,S2]),
+    string_chars(F1, Repr2),
+    string_chars(F2, Repr3),
+    append([Repr1,Repr2,Repr3], Repr).
+    
+    
+    
+
+write_tree_lat(infer(R,red(A,B),[D1,D2]),Repr):-
+    /* predicates with two premises, the left one is colored red and the right one is colored green instead*/
+    write_tree_lat(D1,Repr1),
+    write_tree_lat(D2,Repr2),
+    repr(A, S1),
+    repr(B, S2),
+    swritef(F1,"\\LeftLabel{%w}\n",[R]),
+    swritef(F2,"\\BinaryInfC{$ %w \\Rightarrow %w$}\n",[S1,S2]),
+    string_chars(F1, Repr3),
+    string_chars(F2, Repr4),
+    append([Repr1,Repr2,Repr3,Repr4], Repr).
+


### PR DESCRIPTION
With this PR I'm modifying the term to latex generation phase by separating the string generation with the actual file writing. This allows better handling of different formatting, decoupling the representation with the text generation and possibly allowing different text format generation by adding other predicates to the write_tree module